### PR TITLE
Refactor for separate address and input validation

### DIFF
--- a/home_audit.cli.js
+++ b/home_audit.cli.js
@@ -11,5 +11,5 @@ let validate_address = hes_validation_engine.validate_address;
 let validate_home_audit = hes_validation_engine.validate_home_audit;
 
 const obj = JSON.parse(process.argv[2]);
-let result = Object.assign(validate_address(obj), validate_home_audit(obj))
+const result = Object.assign(validate_address(obj), validate_home_audit(obj));
 console.log(JSON.stringify(result));

--- a/home_audit.cli.js
+++ b/home_audit.cli.js
@@ -6,8 +6,10 @@
  * node home_audit.cli.js '{"solar_electric_capacity_known" : "3"}'
  * > {"solar_electric_capacity_known":"3 is outside the allowed range (0 - 1)"}
  */
-let validate_home_audit = require('./home_audit.node');
+let hes_validation_engine = require('hes-validation-engine');
+let validate_address = hes_validation_engine.validate_address;
+let validate_home_audit = hes_validation_engine.validate_home_audit;
 
 const obj = JSON.parse(process.argv[2]);
-const result = validate_home_audit(obj);
+let result = Object.assign(validate_address(obj), validate_home_audit(obj))
 console.log(JSON.stringify(result));

--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -1227,15 +1227,8 @@ let validationRules = {
     }
 };
 
-/**
- * @param {Object} homeValues Key/value pairs. The keys should be identical to the "name" attributes of the
- * corresponding form fields.
- * @param {Object} additionalRules (Optional) Object of functions. Additonal Validation Rules to be
- * added to present rules.
- * @returns {Object} Keys are the same as in homeValues. Values are error strings. In the event that no
- * validation rules were violated, an empty object is returned.
- */
-function validate_home_audit (homeValues, additionalRules = null) {
+function get_validation_messages (homeValues, requiredFields) {
+  
     // Pass homeValues into the scope of this file so that validation rules can reference it
     // without us having to explicitly pass it to every function
     _homeValues = homeValues;
@@ -1243,7 +1236,7 @@ function validate_home_audit (homeValues, additionalRules = null) {
     result[BLOCKER] = {};
     result[ERROR] = {};
     result[MANDATORY] = {};
-    let requiredFields = require('./required_fields.node')(homeValues);
+
     for (var fieldName in requiredFields) {
         //Because we have two validation rules for one user input, here we check for potential duplicate messages
         if (undefined === homeValues[fieldName] || '' === homeValues[fieldName] || null === homeValues[fieldName]) {
@@ -1281,17 +1274,26 @@ function validate_home_audit (homeValues, additionalRules = null) {
 /**
  * @param {Object} homeValues Key/value pairs. The keys should be identical to the "name" attributes of the
  * corresponding form fields.
+ * @param {Object} additionalRules (Optional) Object of functions. Additonal Validation Rules to be
+ * added to present rules.
+ * @returns {Object} Keys are the same as in homeValues. Values are error strings. In the event that no
+ * validation rules were violated, an empty object is returned.
+ */
+function validate_home_audit (homeValues, additionalRules = null) {
+    // Pass homeValues into the scope of this file so that validation rules can reference it
+    // without us having to explicitly pass it to every function
+    let requiredFields = require('./required_fields.node')(homeValues);
+
+    return get_validation_messages(homeValues, requiredFields);
+}
+
+/**
+ * @param {Object} homeValues Key/value pairs. The keys should be identical to the "name" attributes of the
+ * corresponding form fields.
  * @returns {Object} Keys are the same as in homeValues. Values are error strings. In the event that no
  * validation rules were violated, an empty object is returned.
  */
 function validate_address (homeValues) {
-    // Pass homeValues into the scope of this file so that validation rules can reference it
-    // without us having to explicitly pass it to every function
-    _homeValues = homeValues;
-    let result = {};
-    result[BLOCKER] = {};
-    result[ERROR] = {};
-    result[MANDATORY] = {};
     let mandatoryMessage = "Missing value for mandatory field";
     // Define values that are always required
     let requiredFields = {
@@ -1301,27 +1303,7 @@ function validate_address (homeValues) {
         zip_code : mandatoryMessage,
         assessment_type : mandatoryMessage,
     };
-    for (var fieldName in requiredFields) {
-        //Because we have two validation rules for one user input, here we check for potential duplicate messages
-        if (undefined === homeValues[fieldName] || '' === homeValues[fieldName] || null === homeValues[fieldName]) {
-            result[MANDATORY][fieldName] = requiredFields[fieldName];
-        }
-    }
-    for (let [fieldName, value] of Object.entries(homeValues)) {
-        if (value === null || value === undefined || value.length === 0) {
-            continue;
-        }
-        if (typeof(validationRules[fieldName]) !== 'function') {
-            continue;
-        }
-        let validationResult = validationRules[fieldName](value);
-        if (undefined !== validationResult) {
-            if (undefined !== validationResult['message']) {
-                result[validationResult['type']][fieldName] = validationResult['message'];
-            }
-        }
-    }
-    return result;
+    return get_validation_messages(homeValues, requiredFields);
 }
 
 module.exports = {validate_home_audit, validate_address};

--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -1281,12 +1281,10 @@ function validate_home_audit (homeValues, additionalRules = null) {
 /**
  * @param {Object} homeValues Key/value pairs. The keys should be identical to the "name" attributes of the
  * corresponding form fields.
- * @param {Object} additionalRules (Optional) Object of functions. Additonal Validation Rules to be
- * added to present rules.
  * @returns {Object} Keys are the same as in homeValues. Values are error strings. In the event that no
  * validation rules were violated, an empty object is returned.
  */
-function validate_address (homeValues, additionalRules = null) {
+function validate_address (homeValues) {
     // Pass homeValues into the scope of this file so that validation rules can reference it
     // without us having to explicitly pass it to every function
     _homeValues = homeValues;

--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -1227,10 +1227,11 @@ let validationRules = {
     }
 };
 
-function get_validation_messages (homeValues, requiredFields) {
+function get_validation_messages (homeValues, requiredFields, additionalRules) {
   
     // Pass homeValues into the scope of this file so that validation rules can reference it
     // without us having to explicitly pass it to every function
+    validationRules = additionalRules ? Object.assign(validationRules, additionalRules) : validationRules;
     _homeValues = homeValues;
     let result = {};
     result[BLOCKER] = {};
@@ -1284,7 +1285,7 @@ function validate_home_audit (homeValues, additionalRules = null) {
     // without us having to explicitly pass it to every function
     let requiredFields = require('./required_fields.node')(homeValues);
 
-    return get_validation_messages(homeValues, requiredFields);
+    return get_validation_messages(homeValues, requiredFields, additionalRules);
 }
 
 /**

--- a/required_fields.node.js
+++ b/required_fields.node.js
@@ -31,14 +31,7 @@ module.exports = function (homeValues) {
     //////////////////////////////////////////////////////////////////////////////
     // Add any fields that are required due to the values of other fields       //
     //////////////////////////////////////////////////////////////////////////////
-
-    if (homeValues['building_id_holder'] === '-1') {
-        requiredFields['address'] = mandatoryMessage;
-        requiredFields['city'] = mandatoryMessage;
-        requiredFields['state'] = mandatoryMessage;
-        requiredFields['zip_code'] = mandatoryMessage;
-        requiredFields['assessment_type'] = mandatoryMessage;
-    }
+    
     /*
      * About conitional validations
      */


### PR DESCRIPTION
This PR separates validation for home inputs and required address fields.
- Allow users to distinguish validation between `submit_inputs` and `submit_address` better
- Remove Laravel GUI specific validation of address
- Use for new `copy_template` method