### PR TITLE
Add fallback for NaN if year built not entered

### DIFF
--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -1169,7 +1169,7 @@ let validationRules = {
      */
     _installation_year: function(value, minYear) {
         if(parseInt(value) >= minYear) {
-            return new Validation(TypeRules._int(value, parseInt(_homeValues.year_built) || 1970, (new Date()).getFullYear()), ERROR);
+            return new Validation(isNaN(_homeValues.year_built) ? null : TypeRules._int(value, parseInt(_homeValues.year_built)), (new Date()).getFullYear()), ERROR);
         } else {
             return new Validation(TypeRules._int(value, minYear, (new Date()).getFullYear()), BLOCKER);
         }

--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -1169,7 +1169,7 @@ let validationRules = {
      */
     _installation_year: function(value, minYear) {
         if(parseInt(value) >= minYear) {
-            return new Validation(TypeRules._int(value, parseInt(_homeValues.year_built), (new Date()).getFullYear()), ERROR);
+            return new Validation(TypeRules._int(value, parseInt(_homeValues.year_built) || 1970, (new Date()).getFullYear()), ERROR);
         } else {
             return new Validation(TypeRules._int(value, minYear, (new Date()).getFullYear()), BLOCKER);
         }


### PR DESCRIPTION
We experienced bugginess with this method, triggering the equivalent LBNL error.  This is the only thing I can see that might cause some weirdness.