### PR TITLE
Efficiency method entry conditions

### DIFF
--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -935,9 +935,9 @@ let validationRules = {
         return this._heating_efficiency_method(value, 2);
     },
     _heating_efficiency_method: function(value, num) {
-        const noEfficiencyMethod = ['baseboard', 'central_furnace', 'wood_stove', 'none'];
-        if(value && noEfficiencyMethod.indexOf(_homeValues['heating_type_'+num]) > -1 || TypeRules._is_empty(_homeValues['heating_type_'+num]))) {
-            return new Validation('Efficiency method should not be set if heating type is "baseboard", "central furnace", "wood stove", "none", or empty', ERROR);
+        const noEfficiencyMethod = ['baseboard', 'wood_stove', 'none'];
+        if(value && noEfficiencyMethod.indexOf(_homeValues['heating_type_'+num]) > -1 || (_homeValues['heating_type_'+num] === 'central_furnace' && _homeValues['heating_fuel_'+num] === 'electric') || TypeRules._is_empty(_homeValues['heating_type_'+num])) {
+            return new Validation('Efficiency method should not be set if heating type is "central furnace" and fuel is "electric", or if heating type is "baseboard", "wood stove", "none", or empty', ERROR);
         }
         return new Validation(TypeRules._string(value, 20, ['user', 'shipment_weighted']), BLOCKER);
     },
@@ -988,7 +988,7 @@ let validationRules = {
         return this._cooling_efficiency_method(value, 2);
     },
     _cooling_efficiency_method: function(value, num) {
-        if(value && ['none', 'dec'].indexOf(_homeValues['cooling_type_'+num]) > -1  || TypeRules._is_empty(_homeValues['cooling_type_'+num]))) {
+        if(value && ['none', 'dec'].indexOf(_homeValues['cooling_type_'+num]) > -1  || TypeRules._is_empty(_homeValues['cooling_type_'+num])) {
             return new Validation('Efficiency method should not be set if cooling type is "none", "direct evaporative cooler", or empty', ERROR);
         }
         return new Validation(TypeRules._string(value, 20, ['user', 'shipment_weighted']), BLOCKER);

--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -935,8 +935,9 @@ let validationRules = {
         return this._heating_efficiency_method(value, 2);
     },
     _heating_efficiency_method: function(value, num) {
-        if(value && (_homeValues['heating_type_'+num] === 'none' || TypeRules._is_empty(_homeValues['heating_type_'+num]))) {
-            return new Validation('Efficiency method should not be set if heating type is "none" or empty', ERROR);
+        const noEfficiencyMethod = ['baseboard', 'central_furnace', 'wood_stove', 'none'];
+        if(value && noEfficiencyMethod.indexOf(_homeValues['heating_type_'+num]) > -1 || TypeRules._is_empty(_homeValues['heating_type_'+num]))) {
+            return new Validation('Efficiency method should not be set if heating type is "baseboard", "central furnace", "wood stove", "none", or empty', ERROR);
         }
         return new Validation(TypeRules._string(value, 20, ['user', 'shipment_weighted']), BLOCKER);
     },

--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -987,8 +987,8 @@ let validationRules = {
         return this._cooling_efficiency_method(value, 2);
     },
     _cooling_efficiency_method: function(value, num) {
-        if(value && (_homeValues['cooling_type_'+num] === 'none' || TypeRules._is_empty(_homeValues['cooling_type_'+num]))) {
-            return new Validation('Efficiency method should not be set if cooling type is "none" or empty', ERROR);
+        if(value && ['none', 'dec'].indexOf(_homeValues['cooling_type_'+num]) > -1  || TypeRules._is_empty(_homeValues['cooling_type_'+num]))) {
+            return new Validation('Efficiency method should not be set if cooling type is "none", "direct evaporative cooler", or empty', ERROR);
         }
         return new Validation(TypeRules._string(value, 20, ['user', 'shipment_weighted']), BLOCKER);
     },

--- a/home_audit.node.js
+++ b/home_audit.node.js
@@ -935,8 +935,9 @@ let validationRules = {
         return this._heating_efficiency_method(value, 2);
     },
     _heating_efficiency_method: function(value, num) {
-        const noEfficiencyMethod = ['baseboard', 'wood_stove', 'none'];
-        if(value && noEfficiencyMethod.indexOf(_homeValues['heating_type_'+num]) > -1 || (_homeValues['heating_type_'+num] === 'central_furnace' && _homeValues['heating_fuel_'+num] === 'electric') || TypeRules._is_empty(_homeValues['heating_type_'+num])) {
+        const isHeatingTypeWithoutEfficiencyMethod = ['baseboard', 'wood_stove', 'none'].indexOf(_homeValues['heating_type_'+num]) > -1;
+        const isElectricFurnace = _homeValues['heating_type_'+num] === 'central_furnace' && _homeValues['heating_fuel_'+num] === 'electric';
+        if(!TypeRules._is_empty(value) && (isHeatingTypeWithoutEfficiencyMethod || isElectricFurnace || TypeRules._is_empty(_homeValues['heating_type_'+num]))) {
             return new Validation('Efficiency method should not be set if heating type is "central furnace" and fuel is "electric", or if heating type is "baseboard", "wood stove", "none", or empty', ERROR);
         }
         return new Validation(TypeRules._string(value, 20, ['user', 'shipment_weighted']), BLOCKER);
@@ -988,7 +989,7 @@ let validationRules = {
         return this._cooling_efficiency_method(value, 2);
     },
     _cooling_efficiency_method: function(value, num) {
-        if(value && ['none', 'dec'].indexOf(_homeValues['cooling_type_'+num]) > -1  || TypeRules._is_empty(_homeValues['cooling_type_'+num])) {
+        if(!TypeRules._is_empty(value) && (['none', 'dec'].indexOf(_homeValues['cooling_type_'+num]) > -1  || TypeRules._is_empty(_homeValues['cooling_type_'+num]))) {
             return new Validation('Efficiency method should not be set if cooling type is "none", "direct evaporative cooler", or empty', ERROR);
         }
         return new Validation(TypeRules._string(value, 20, ['user', 'shipment_weighted']), BLOCKER);


### PR DESCRIPTION
To resolve missed LBNL validation.  See below...

"Building 277770 triggered LBNL Validation Engine errors. Please update the HES Validation Engine to generate a message for this case. Message(s): "//hvac[2]/cooling/efficiency: Input is required if hvac2 cooling.efficiency_method is set to user and hvac2 cooling.type is set to dec", "//hvac[2]/heating/efficiency: Input is required if hvac2 heating efficiency is set to user and hvac2 heating.type is set to wood_stove" (application name: "Production Access")"