### PR TITLE
Fix wall all showing missing field even one field is missing

### DIFF
--- a/src/translate_legacy.ts
+++ b/src/translate_legacy.ts
@@ -400,7 +400,7 @@ export function translateHomeValues(flat:any): HEScoreJSONSchema {
                 !keys.some(
                     (key) =>
                         !isEmpty(clearedObj[key]) &&
-                        !['side', 'name', 'hvac_name', 'roof_name', 'floor_name'].includes(key) &&
+                        !['name', 'hvac_name', 'roof_name', 'floor_name'].includes(key) &&
                         !(['hvac_fraction', 'fraction'].includes(key) && clearedObj[key] === 0)
                 )
             ) {


### PR DESCRIPTION
This is to fix missing fields are shown for all walls when just one wall is not set, like image as follow:
![image](https://github.com/hes-pnnl/hes-validation-engine/assets/4979985/71acdc88-93fc-4c84-b358-1575e62276c1)
